### PR TITLE
docs: #7 返却値の型指定

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { Practice } from "./pratices/Practice";
+import { PracticeReturn } from "./pratices/PracticeReturn";
 
 export default function App() {
   return (
     <div>
       <Practice />
+      <PracticeReturn />
     </div>
   );
 }

--- a/src/pratices/PracticeReturn.tsx
+++ b/src/pratices/PracticeReturn.tsx
@@ -1,0 +1,13 @@
+export const PracticeReturn = () => {
+  const getTotalFee = (num: number): number => {
+    const total = num * 1.1;
+    return total;
+  };
+  const onClickPractice = () => console.log(getTotalFee(100));
+  return (
+    <div>
+      <p>練習問題:返却値の型指定</p>
+      <button onClick={onClickPractice}>練習問題2を実行</button>
+    </div>
+  );
+};


### PR DESCRIPTION
## TypeScriptの返却値型指定
・Practiceディレクトリ内のPracticeReturn.tsxにて返却値の型指定実践

## ポイント
・引数の型指定をした場合、返却値のデフォルトの型指定が引数の型指定に自動的になるケースもあるため、返却値が複雑でない場合、可読性という点で指定しないこともある。